### PR TITLE
PKG-14790 jupyter-rfb 1.0.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "jupyter-rfb" %}
-{% set version = "0.5.3" %}
+{% set version = "1.0.2" %}
 
 
 package:
@@ -8,49 +8,32 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name|replace("-", "_") }}-{{ version }}.tar.gz
-  sha256: 45549b1b36614195f76d33a1c299b21628d5aa4b3b4ed9a4b49b4888c98b2191
+  sha256: b77a9a464e2da6d0b345b3989f037c4db2fc0c34da3379b380c42baeb0b3abca
 
 build:
   number: 0
   skip: true  # [py<39]
-  script_env:
-    - JUPYTER_PACKAGING_SKIP_NPM=1
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   host:
     - python
     - pip
-    - hatchling
-    - hatch-jupyter-builder
-    - jupyterlab >=3.0.0,<5.0.0
-    # Versions for 'yarn' not specified in pyproject.toml, taken from conda-forge.
-    - yarn >=1.22,<2
+    - flit-core >=3.2,<4
   run:
     - python
-    - ipywidgets >=7.6.0,<9.0.0
+    - anywidget
     - numpy
-    # Not in pyproject.toml but recommended for better performance:
-    # https://github.com/vispy/jupyter_rfb/blob/v0.5.3/README.md?plain=1#L39
-    # Without it (or put in 'run_constrained') some tests are failing.
-    - pillow
+    - simplejpeg
 
 test:
-  source_files:
-    - tests
   imports:
     - jupyter_rfb
   requires:
     - pip
-    - pytest
-    - jupyterlab
+    - anywidget
   commands:
     - pip check
-    - jupyter labextension list
-    - jupyter labextension list 1>labextensions 2>&1
-    - cat labextensions | grep "jupyter_rfb.*OK.*jupyter_rfb"  # [unix]
-    # test_writing occasionally fails on CI causing PermissionError
-    - pytest -v tests/ -k "not test_writing"
 
 about:
   home: https://github.com/vispy/jupyter_rfb
@@ -59,8 +42,8 @@ about:
   license_file: LICENSE
   summary: Remote Frame Buffer for Jupyter
   description: |
-    The jupyter_rfb library provides a widget (an ipywidgets subclass) that can be used
-    in the Jupyter notebook and in JupyterLab to implement a remote frame-buffer.
+    The jupyter_rfb library provides a widget (an anywidget subclass) that can be used
+    in various notebook environments to implement a remote frame-buffer.
   dev_url: https://github.com/vispy/jupyter_rfb
   doc_url: https://jupyter-rfb.readthedocs.io
 


### PR DESCRIPTION
## jupyter-rfb 1.0.2

**Destination channel:** main

### Links
- [PKG-14790](https://anaconda.atlassian.net/browse/PKG-14790)
- [PyPI](https://pypi.org/project/jupyter-rfb/1.0.2/)
- [Upstream](https://github.com/vispy/jupyter_rfb/tree/v1.0.2)

### Explanation of changes
- Updated jupyter-rfb from 0.5.3 to 1.0.2
- Switched build backend from hatchling/hatch-jupyter-builder to flit-core (upstream 1.x rewrite)
- Replaced ipywidgets/pillow run deps with anywidget + simplejpeg (upstream runtime deps)
- Dropped labextension/yarn build and pytest suite (package no longer ships frontend assets or tests in sdist)

### Notes
- Blocked on simplejpeg 1.9.0 for pkgs/main — now released; CI re-triggered

[PKG-14790]: https://anaconda.atlassian.net/browse/PKG-14790?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ